### PR TITLE
check length when testing topics endpoint and remove 'require fs'

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -27,10 +27,12 @@ describe("/api/topics", () => {
         .get("/api/topics")
         .expect(200)
         .then(({ body }) => {
-            body.topics.forEach(topic => {
-                expect(typeof topic.description).toBe("string");
-                expect(typeof topic.slug).toBe("string")
-            });
+            if (body.topics.length > 0) {
+                body.topics.forEach(topic => {
+                    expect(typeof topic.description).toBe("string");
+                    expect(typeof topic.slug).toBe("string")
+                });
+            }
         });
     });
 });

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -1,4 +1,3 @@
-const fs = require("fs/promises")
 const db = require("../db/connection")
 
 exports.fetchTopics = () => {


### PR DESCRIPTION
corrected app test to check the length of the topics array before testing its elements
removed "fs" from topics.model.js